### PR TITLE
Add patches for CVE-2026-34180 and CVE-2026-7383

### DIFF
--- a/SOURCES/0001-CVE-2026-34180-avoid-length-truncation-in-ASN1_STRING_set.patch
+++ b/SOURCES/0001-CVE-2026-34180-avoid-length-truncation-in-ASN1_STRING_set.patch
@@ -1,0 +1,95 @@
+From da5d62af75f69d6fbf7803743d7c56ac75461e43 Mon Sep 17 00:00:00 2001
+From: Viktor Dukhovni <openssl-users@dukhovni.org>
+Date: Tue, 7 Apr 2026 22:40:55 +1000
+Subject: [PATCH] Avoid length truncation in ASN1_STRING_set
+
+The ASN1_STRING_set() function takes an `int` length, make sure the
+argument is not inadvertently truncated when it is called from
+asn1_ex_c2i().
+
+Fixes CVE-2026-34180
+
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Mon Jun  8 14:13:56 2026
+(cherry picked from commit 5f525cace61a53311ee533374919356c700847d9)
+---
+ crypto/asn1/tasn_dec.c | 24 +++++++++++++++++-------
+ 1 file changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/crypto/asn1/tasn_dec.c b/crypto/asn1/tasn_dec.c
+index 91c2e524f55b9..e9532b9f48f74 100644
+--- a/crypto/asn1/tasn_dec.c
++++ b/crypto/asn1/tasn_dec.c
+@@ -54,7 +54,7 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
+     const ASN1_ITEM *it,
+     int tag, int aclass, char opt,
+     ASN1_TLC *ctx);
+-static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
++static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, long len,
+     int utype, char *free_cont, const ASN1_ITEM *it);
+ 
+ /* Table to convert tags to bit values, used for MSTRING type */
+@@ -855,19 +855,24 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
+ 
+ /* Translate ASN1 content octets into a structure */
+ 
+-static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
++static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, long len,
+     int utype, char *free_cont, const ASN1_ITEM *it)
+ {
+     ASN1_VALUE **opval = NULL;
+     ASN1_STRING *stmp;
+     ASN1_TYPE *typ = NULL;
+     int ret = 0;
++    int ilen = (int)len;
+     const ASN1_PRIMITIVE_FUNCS *pf;
+     ASN1_INTEGER **tint;
+     pf = it->funcs;
+ 
+-    if (pf && pf->prim_c2i)
+-        return pf->prim_c2i(pval, cont, len, utype, free_cont, it);
++    if (pf && pf->prim_c2i) {
++        if (len == (long)ilen)
++            return pf->prim_c2i(pval, cont, ilen, utype, free_cont, it);
++        ERR_raise(ERR_LIB_ASN1, ASN1_R_TOO_LONG);
++        return 0;
++    }
+     /* If ANY type clear type and set pointer to internal value */
+     if (it->utype == V_ASN1_ANY) {
+         if (*pval == NULL) {
+@@ -885,7 +890,8 @@ static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
+     }
+     switch (utype) {
+     case V_ASN1_OBJECT:
+-        if (!ossl_c2i_ASN1_OBJECT((ASN1_OBJECT **)pval, &cont, len))
++        if (len != (long)ilen
++            || !ossl_c2i_ASN1_OBJECT((ASN1_OBJECT **)pval, &cont, ilen))
+             goto err;
+         break;
+ 
+@@ -940,6 +946,10 @@ static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
+     case V_ASN1_SET:
+     case V_ASN1_SEQUENCE:
+     default:
++        if (len != (long)ilen) {
++            ERR_raise(ERR_LIB_ASN1, ASN1_R_TOO_LONG);
++            goto err;
++        }
+         if (utype == V_ASN1_BMPSTRING && (len & 1)) {
+             ERR_raise(ERR_LIB_ASN1, ASN1_R_BMPSTRING_IS_WRONG_LENGTH);
+             goto err;
+@@ -970,10 +980,10 @@ static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
+         }
+         /* If we've already allocated a buffer use it */
+         if (*free_cont) {
+-            ASN1_STRING_set0(stmp, (unsigned char *)cont /* UGLY CAST! */, len);
++            ASN1_STRING_set0(stmp, (unsigned char *)cont /* UGLY CAST! */, ilen);
+             *free_cont = 0;
+         } else {
+-            if (!ASN1_STRING_set(stmp, cont, len)) {
++            if (!ASN1_STRING_set(stmp, cont, ilen)) {
+                 ERR_raise(ERR_LIB_ASN1, ERR_R_ASN1_LIB);
+                 ASN1_STRING_free(stmp);
+                 *pval = NULL;

--- a/SOURCES/0002-CVE-2026-7383-reject-oversized-inputs-in-ASN1_mbstring_ncopy.patch
+++ b/SOURCES/0002-CVE-2026-7383-reject-oversized-inputs-in-ASN1_mbstring_ncopy.patch
@@ -1,0 +1,110 @@
+From 80c15faaf78042bbb8654a0e234c50c381732f74 Mon Sep 17 00:00:00 2001
+From: Viktor Dukhovni <viktor@openssl.org>
+Date: Wed, 29 Apr 2026 18:23:24 +1000
+Subject: [PATCH] Reject oversized inputs in ASN1_mbstring_ncopy()
+
+In ASN1_mbstring_ncopy() the destination size for BMPSTRING and
+UNIVERSALSTRING output was computed by a signed left shift on an
+int:
+
+    outlen = nchar << 1;        /* MBSTRING_BMP  */
+    outlen = nchar << 2;        /* MBSTRING_UNIV */
+
+For nchar large enough the result is not representable in int.  In
+the worst case (nchar == 0x40000000) nchar << 2 wraps to zero,
+OPENSSL_malloc(1) is called, and traverse_string() then writes
+4*nchar bytes into the one-byte allocation: a heap buffer
+overflow.  The MBSTRING_UTF8 path computes outlen by summing
+per-character byte counts in out_utf8(), and that sum can overflow
+the same int under similarly large inputs.
+
+Neither path is reachable from code that processes X.509
+certificates through the DIRSTRING_TYPE mask used by
+ASN1_STRING_set_by_NID(): UNIVERSALSTRING is absent from that
+mask, and the UTF-8 sum requires inputs on the order of half a
+gigabyte.  Reaching them needs an application that calls
+ASN1_mbstring_copy()/ASN1_mbstring_ncopy() directly, or registers
+a custom NID via ASN1_STRING_TABLE_add(), with an oversized
+attacker-controlled input.
+
+Add range checks before each shift and in out_utf8(), raising
+ASN1_R_STRING_TOO_LONG at the point of detection.  Move the
+existing ASN1_R_INVALID_UTF8STRING raise into out_utf8() too so
+the two failure modes report distinct codes; the MBSTRING_UTF8
+caller is left with cleanup only and now frees dest on error,
+matching the BMP/UNIV branches.
+
+Fixes CVE-2026-7383
+
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+Reviewed-by: Daniel Kubec <kubec@openssl.foundation>
+MergeDate: Mon Jun  8 13:59:47 2026
+(cherry picked from commit d32350ae8ef7426718f5aa9e383d4b51398ee255)
+---
+ crypto/asn1/a_mbstr.c | 31 ++++++++++++++++++++++++++++---
+ 1 file changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/crypto/asn1/a_mbstr.c b/crypto/asn1/a_mbstr.c
+index 2270e63d51d4e..962e19b2ceaa9 100644
+--- a/crypto/asn1/a_mbstr.c
++++ b/crypto/asn1/a_mbstr.c
+@@ -174,11 +174,27 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
+         break;
+ 
+     case MBSTRING_BMP:
++        if (nchar > INT_MAX / 2) {
++            ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
++            if (free_out) {
++                ASN1_STRING_free(dest);
++                *out = NULL;
++            }
++            return -1;
++        }
+         outlen = nchar << 1;
+         cpyfunc = cpy_bmp;
+         break;
+ 
+     case MBSTRING_UNIV:
++        if (nchar > INT_MAX / 4) {
++            ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
++            if (free_out) {
++                ASN1_STRING_free(dest);
++                *out = NULL;
++            }
++            return -1;
++        }
+         outlen = nchar << 2;
+         cpyfunc = cpy_univ;
+         break;
+@@ -186,8 +202,11 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
+     case MBSTRING_UTF8:
+         outlen = 0;
+         ret = traverse_string(in, len, inform, out_utf8, &outlen);
+-        if (ret < 0) {
+-            ERR_raise(ERR_LIB_ASN1, ASN1_R_INVALID_UTF8STRING);
++        if (ret < 0) { /* error already raised in out_utf8() */
++            if (free_out) {
++                ASN1_STRING_free(dest);
++                *out = NULL;
++            }
+             return -1;
+         }
+         cpyfunc = cpy_utf8;
+@@ -270,9 +289,15 @@ static int out_utf8(unsigned long value, void *arg)
+     int *outlen, len;
+ 
+     len = UTF8_putc(NULL, -1, value);
+-    if (len <= 0)
++    if (len <= 0) {
++        ERR_raise(ERR_LIB_ASN1, ASN1_R_INVALID_UTF8STRING);
+         return len;
++    }
+     outlen = arg;
++    if (*outlen > INT_MAX - len) {
++        ERR_raise(ERR_LIB_ASN1, ASN1_R_STRING_TOO_LONG);
++        return -1;
++    }
+     *outlen += len;
+     return 1;
+ }

--- a/SPECS/openssl.spec
+++ b/SPECS/openssl.spec
@@ -19,7 +19,7 @@ Name:    openssl
 Epoch:   1
 %endif
 Version: 3.5.5
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 Source0: openssl-3.5.5.tar.gz
 Patch0: 0002-Add-a-separate-config-file-to-use-for-rpm-installs.patch
 Patch1: 0003-RH-Do-not-install-html-docs.patch
@@ -37,6 +37,11 @@ Patch12: 0016-RH-Allow-disabling-of-SHA1-signatures.patch
 Patch13: 0051-Backport-upstream-27483-for-PKCS11-needs.patch
 Patch14: 0056-Add-targets-to-skip-build-of-non-installable-program.patch
 Patch15: pass_ipv6_address_correctly
+
+# XCP-ng patches
+Patch1001: 0001-CVE-2026-34180-avoid-length-truncation-in-ASN1_STRING_set.patch
+Patch1002: 0002-CVE-2026-7383-reject-oversized-inputs-in-ASN1_mbstring_ncopy.patch
+
 # Source1: fips-hmacify.sh
 Source1: 0001-For-XenServer-8.4-retain-support-for-SHA1-signatures.patch
 
@@ -301,6 +306,10 @@ basearch=%{_arch}
 %ldconfig_scriptlets libs
 
 %changelog
+* Mon Jul 27 2026 Vincent Michel <vincent.michel@vates.tech> - 1:3.5.5-1.2
+- Fixes CVE-2026-34180: Avoid length truncation in ASN1_STRING_set
+- Fixes CVE-2026-7383: Reject oversized inputs in ASN1_mbstring_ncopy()
+
 * Thu May 28 2026 Vincent Michel <vincent.michel@vates.tech> - 1:3.5.5-1.1
 - *** Upstream changelog ***
   * Mon Mar 02 2026 Mark Syms  <mark.syms@citrix.com> - 1:3.5.5-1


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3516

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

PR #7 (XCPNG-3273) has to be merged first, so the target branch for this PR can be set to `8.3`

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Address the following CVE:
- [CVE-2026-7383](https://nvd.nist.gov/vuln/detail/CVE-2026-7383)
- [CVE-2026-34180](https://nvd.nist.gov/vuln/detail/CVE-2026-34180)

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Same as #7, i.e `8.3-next+1`

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

**Question**: is there anything specific to tell uses besides that those two CVEs are addressed?

Address CVE-2026-34180 and CVE-2026-7383

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

I don't think those two patches require any documentation update.

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

I built user packages and installed them on three hosts, then ran the following jobs:
- `main`
- `linstor-main`
- `linstor-reboots`
- `linstor-quicktest`
- `linstor-migrations`

They all passed.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

I don't think those two patches require any manual test.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

The main job includes the following tests:
- `tests/security/test_tls.py::test_tls_disabled[TLSv1]`
- `tests/security/test_tls.py::test_tls_disabled[TLSv1.1]`
- `tests/security/test_tls.py::test_enabled[TLSv1.2]`
- `tests/xapi/tls_verification/test_tls_verification.py::TestTLSVerification::test_tls_verification`
- `tests/xapi/tls_verification/test_tls_verification.py::TestTLSVerification::test_refresh_certificate`
- `tests/xapi/tls_verification/test_tls_verification.py::TestTLSVerification::test_break_cert`
- `tests/xapi/tls_verification/test_tls_verification.py::TestTLSVerification::test_toolstack_restart`

#### What tests have been or will be added to CI for this change? If none, explain why.

I don't think those two patches require any extra test in the CI.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
