### PR TITLE
Restore `0008-Add-FIPS_mode-compatibility-macro.patch`

### DIFF
--- a/SOURCES/0008-Add-FIPS_mode-compatibility-macro.patch
+++ b/SOURCES/0008-Add-FIPS_mode-compatibility-macro.patch
@@ -1,0 +1,87 @@
+From 5b2ec9a54037d7b007324bf53e067e73511cdfe4 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tmraz@fedoraproject.org>
+Date: Thu, 26 Nov 2020 14:00:16 +0100
+Subject: Add FIPS_mode() compatibility macro
+
+The macro calls EVP_default_properties_is_fips_enabled() on the
+default context.
+---
+ include/openssl/crypto.h.in |  1 +
+ include/openssl/fips.h      | 25 +++++++++++++++++++++++++
+ test/property_test.c        | 13 +++++++++++++
+ 3 files changed, 39 insertions(+)
+ create mode 100644 include/openssl/fips.h
+
+diff --git a/include/openssl/crypto.h.in b/include/openssl/crypto.h.in
+index 1036da9a2b..9d4896fcaf 100644
+--- a/include/openssl/crypto.h.in
++++ b/include/openssl/crypto.h.in
+@@ -38,6 +38,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
+ # include <openssl/opensslconf.h>
+ # include <openssl/cryptoerr.h>
+ # include <openssl/core.h>
++# include <openssl/fips.h>
+ 
+ # ifdef CHARSET_EBCDIC
+ #  include <openssl/ebcdic.h>
+diff --git a/include/openssl/fips.h b/include/openssl/fips.h
+new file mode 100644
+index 0000000000..c64f0f8e8f
+--- /dev/null
++++ b/include/openssl/fips.h
+@@ -0,0 +1,25 @@
++/*
++ * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
++ *
++ * Licensed under the Apache License 2.0 (the "License").  You may not use
++ * this file except in compliance with the License.  You can obtain a copy
++ * in the file LICENSE in the source distribution or at
++ * https://www.openssl.org/source/license.html
++ */
++
++#ifndef OPENSSL_FIPS_H
++# define OPENSSL_FIPS_H
++# pragma once
++
++# include <openssl/macros.h>
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++# define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
++
++# ifdef __cplusplus
++}
++# endif
++#endif
+diff -up openssl-3.0.0-beta1/test/property_test.c.fips-macro openssl-3.0.0-beta1/test/property_test.c
+--- openssl-3.0.0-beta1/test/property_test.c.fips-macro	2021-06-29 12:14:58.851557698 +0200
++++ openssl-3.0.0-beta1/test/property_test.c	2021-06-29 12:17:14.630143832 +0200
+@@ -488,6 +488,18 @@ static int test_property_list_to_string(
+     return ret;
+ }
+ 
++static int test_downstream_FIPS_mode(void)
++{
++    int ret = 0;
++
++    ret = TEST_true(EVP_set_default_properties(NULL, "fips=yes"))
++          && TEST_true(FIPS_mode())
++          && TEST_true(EVP_set_default_properties(NULL, "fips=no"))
++          && TEST_false(FIPS_mode());
++
++    return ret;
++}
++
+ int setup_tests(void)
+ {
+     ADD_TEST(test_property_string);
+@@ -500,6 +512,7 @@ int setup_tests(void)
+     ADD_TEST(test_property);
+     ADD_TEST(test_query_cache_stochastic);
+     ADD_TEST(test_fips_mode);
++    ADD_TEST(test_downstream_FIPS_mode);
+     ADD_ALL_TESTS(test_property_list_to_string, OSSL_NELEM(to_string_tests));
+     return 1;
+ }

--- a/SOURCES/0008-Add-FIPS_mode-compatibility-macro.patch
+++ b/SOURCES/0008-Add-FIPS_mode-compatibility-macro.patch
@@ -1,10 +1,12 @@
-From 5b2ec9a54037d7b007324bf53e067e73511cdfe4 Mon Sep 17 00:00:00 2001
 From: Tomas Mraz <tmraz@fedoraproject.org>
 Date: Thu, 26 Nov 2020 14:00:16 +0100
 Subject: Add FIPS_mode() compatibility macro
 
 The macro calls EVP_default_properties_is_fips_enabled() on the
 default context.
+
+Updated by Vincent Michel <vincent.michel@vates.tech>, on
+Mon, 24 Aug 2026 19:32:22 +0200
 ---
  include/openssl/crypto.h.in |  1 +
  include/openssl/fips.h      | 25 +++++++++++++++++++++++++
@@ -13,20 +15,20 @@ default context.
  create mode 100644 include/openssl/fips.h
 
 diff --git a/include/openssl/crypto.h.in b/include/openssl/crypto.h.in
-index 1036da9a2b..9d4896fcaf 100644
+index 696eabb..39866a3 100644
 --- a/include/openssl/crypto.h.in
 +++ b/include/openssl/crypto.h.in
-@@ -38,6 +38,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
- # include <openssl/opensslconf.h>
- # include <openssl/cryptoerr.h>
- # include <openssl/core.h>
-+# include <openssl/fips.h>
+@@ -40,6 +40,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
+ #include <openssl/opensslconf.h>
+ #include <openssl/cryptoerr.h>
+ #include <openssl/core.h>
++#include <openssl/fips.h>
  
- # ifdef CHARSET_EBCDIC
- #  include <openssl/ebcdic.h>
+ #ifdef CHARSET_EBCDIC
+ #include <openssl/ebcdic.h>
 diff --git a/include/openssl/fips.h b/include/openssl/fips.h
 new file mode 100644
-index 0000000000..c64f0f8e8f
+index 0000000..c64f0f8
 --- /dev/null
 +++ b/include/openssl/fips.h
 @@ -0,0 +1,25 @@
@@ -55,10 +57,11 @@ index 0000000000..c64f0f8e8f
 +}
 +# endif
 +#endif
-diff -up openssl-3.0.0-beta1/test/property_test.c.fips-macro openssl-3.0.0-beta1/test/property_test.c
---- openssl-3.0.0-beta1/test/property_test.c.fips-macro	2021-06-29 12:14:58.851557698 +0200
-+++ openssl-3.0.0-beta1/test/property_test.c	2021-06-29 12:17:14.630143832 +0200
-@@ -488,6 +488,18 @@ static int test_property_list_to_string(
+diff --git a/test/property_test.c b/test/property_test.c
+index d470731..a47f495 100644
+--- a/test/property_test.c
++++ b/test/property_test.c
+@@ -703,6 +703,18 @@ err:
      return ret;
  }
  
@@ -77,11 +80,14 @@ diff -up openssl-3.0.0-beta1/test/property_test.c.fips-macro openssl-3.0.0-beta1
  int setup_tests(void)
  {
      ADD_TEST(test_property_string);
-@@ -500,6 +512,7 @@ int setup_tests(void)
+@@ -716,6 +728,7 @@ int setup_tests(void)
      ADD_TEST(test_property);
      ADD_TEST(test_query_cache_stochastic);
      ADD_TEST(test_fips_mode);
 +    ADD_TEST(test_downstream_FIPS_mode);
      ADD_ALL_TESTS(test_property_list_to_string, OSSL_NELEM(to_string_tests));
+     ADD_TEST(test_property_list_to_string_bounds);
      return 1;
- }
+-- 
+1.8.3.1
+

--- a/SPECS/openssl.spec
+++ b/SPECS/openssl.spec
@@ -39,8 +39,11 @@ Patch14: 0056-Add-targets-to-skip-build-of-non-installable-program.patch
 Patch15: pass_ipv6_address_correctly
 
 # XCP-ng patches
-Patch1001: 0001-CVE-2026-34180-avoid-length-truncation-in-ASN1_STRING_set.patch
-Patch1002: 0002-CVE-2026-7383-reject-oversized-inputs-in-ASN1_mbstring_ncopy.patch
+# This patch was removed between versions 3.0.9-2.0.1 and 1:3.5.5-1
+# It provides the header file 'fips.h' which is necessary to build openSSH
+Patch1001: 0008-Add-FIPS_mode-compatibility-macro.patch
+Patch1002: 0001-CVE-2026-34180-avoid-length-truncation-in-ASN1_STRING_set.patch
+Patch1003: 0002-CVE-2026-7383-reject-oversized-inputs-in-ASN1_mbstring_ncopy.patch
 
 # Source1: fips-hmacify.sh
 Source1: 0001-For-XenServer-8.4-retain-support-for-SHA1-signatures.patch

--- a/SPECS/openssl.spec
+++ b/SPECS/openssl.spec
@@ -19,7 +19,7 @@ Name:    openssl
 Epoch:   1
 %endif
 Version: 3.5.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 Source0: openssl-3.5.5.tar.gz
 Patch0: 0002-Add-a-separate-config-file-to-use-for-rpm-installs.patch
 Patch1: 0003-RH-Do-not-install-html-docs.patch
@@ -309,6 +309,9 @@ basearch=%{_arch}
 %ldconfig_scriptlets libs
 
 %changelog
+* Mon Aug 24 2026 Vincent Michel <vincent.michel@vates.tech> - 1:3.5.5-1.3
+- Restore '0008-Add-FIPS_mode-compatibility-macro.patch' to provide 'fips.h'
+
 * Mon Jul 27 2026 Vincent Michel <vincent.michel@vates.tech> - 1:3.5.5-1.2
 - Fixes CVE-2026-34180: Avoid length truncation in ASN1_STRING_set
 - Fixes CVE-2026-7383: Reject oversized inputs in ASN1_mbstring_ncopy()


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3273

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

This change will be released at the same time as #7 and #8.
More precisely, it should have been part of #7 but was missed during tests and review.

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

In #7, we imported `openssl-3.5.5-1.xs8` which removes a patch that adds a `fips.h` header file for FIPS  mode compatibility. Even though we don't use FIPS, this file is required to build other packages, such as openSSH and krb5.

As a side note, I noticed that no `fips.h` include appears in the openSSH source tarball, but it's still required due to [this patch](https://github.com/xcp-ng-rpms/openssh/blob/40989b8e1a6012e7454dab56d86b6833b57c556c/SOURCES/openssh-7.7p1-fips.patch#L8). We might want to investigate a possible cleanup of all patches that have a reference to `fips.h`, for all the packages that have `openssl-devel` as a build requirements.

In the meantime, the simplest fix is simply to restore the `0008-Add-FIPS_mode-compatibility-macro.patch` patch that was removed between versions 3.0.9-2.0.1 and 1:3.5.5-1 by XenServer. 

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

`8.3-next+1`

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

This change is part of the update to openssl 3.5, so see the corresponding section in #7

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

In #7, we missed the missing `fips.h` header file because we do not rebuild the packages depending on `openssl` automatically. In order to make sure that `fips.h` is not the only breaking change, I manually re-built all the following packages:
- bind
- blktap
- cmake3
- coreutils
- createrepo_c
- curl
- glusterfs
- iperf3
- ipmitool
- iputils
- krb5
- ldns
- ldns
- libarchive
- libssh2
- libtpms
- net-snmp
- netdata
- nut
- openssh
- openvswitch
- python
- python3
- python-pycurl
- rsync
- samba
- socat
- ssmtp
- stunnel
- sudo
- swtpm
- tcpdump
- trousers
- uefistored
- varstored
- xapi
- xs-opam-repo
- zfs

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

This change is part of the update to openssl 3.5, and it was decided in #7 that no documentation update is needed. This extra patch does require a documentation update either.

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

On top of the tests mentioned in #7, I triggered a rebuild of all the packages listed above. All of them passed, except for 6 of them:
- krb5
  - already fails with previous version as it requires packages from `xcp-ng-pcoval2` such as `lmdb-devel`
  - build succeeds with `xcp-ng-pcoval2` enabled
- libssh2
  - already failed with previous version, requires a patch for the tests
  - TODO: make sure the build succeeds with the patch 
- python 
  - fails the tests due to `test_poplib` blocking indefinitely
  - the build succeeds with `EXTRATESTOPTS="$EXTRATESTOPTS -x test_poplib"`
  - a [PR has been created to fix the tests](https://github.com/xcp-ng-rpms/python/pull/2)
- python3
  - already fails the `test_ssl` tests with previous version
  - [a PR has been PR created to fix the tests](https://github.com/xcp-ng-rpms/python3/pull/2)
- samba
  - already fails with previous version as it requires packages from `xcp-ng-pcoval2` such as `lmdb-devel`
  - build succeeds with `xcp-ng-pcoval2` enabled
- uefistored
  - already failed with previous version during build with `error: unknown type name 'xc_dominfo_t'`
  - apparently this package is not used anymore
  - TODO: should we archive the repository?


#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

This change is part of the update to openssl 3.5, so see the corresponding section in #7.

This specific patch does not require more testing than what's described in #7.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

This change is part of the update to openssl 3.5, so see the corresponding section in #7 (and this patch does not affect what's already described there).

#### What tests have been or will be added to CI for this change? If none, explain why.

This change is part of the update to openssl 3.5, so see the corresponding section in #7 (and this patch does not affect what's already described there).

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
